### PR TITLE
Fix dialog and windows

### DIFF
--- a/app/js/renderer/components/menubar.jsx
+++ b/app/js/renderer/components/menubar.jsx
@@ -11,7 +11,7 @@ export default class Menubar extends React.Component {
     ipcRenderer.on('focus', this.onFocus);
   }
   openLoad = () => {
-    const files = remote.dialog.showOpenDialog({
+    const files = remote.dialog.showOpenDialogSync({
       title: 'Open Project',
       defaultPath: this.props.projectPath,
       filters: [{

--- a/app/js/renderer/components/selectFrameLayout.jsx
+++ b/app/js/renderer/components/selectFrameLayout.jsx
@@ -10,7 +10,7 @@ export default class Layout extends React.Component {
     }
   }
   componentDidMount() {
-    window.onresize = ::this.onResize;
+    window.onresize = this.onResize.bind(this);
   }
   onResize() {
     this.setState({ height: window.innerHeight });

--- a/app/js/renderer/components/toolbarProperties.jsx
+++ b/app/js/renderer/components/toolbarProperties.jsx
@@ -99,7 +99,7 @@ export default class ToolbarProperties extends React.Component {
     this.updateProperty(prop, String(value));
   }
   openFile = () => {
-    const filePaths = remote.dialog.showOpenDialog({
+    const filePaths = remote.dialog.showOpenDialogSync({
       title: 'Select Image',
       defaultPath: this.props.mapObject.filePath,
       filters: [{

--- a/app/js/renderer/selectCondition.js
+++ b/app/js/renderer/selectCondition.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { ipcRenderer } from 'electron'
 
-import Layout from './components/selectConditionLayout'
+import Layout from './components/selectConditionLayout.jsx'
 
 ipcRenderer.on('init', (event, data) => {
   ReactDOM.render(

--- a/app/js/renderer/selectFrame.js
+++ b/app/js/renderer/selectFrame.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { ipcRenderer } from 'electron'
 
-import Layout from './components/selectFrameLayout'
+import Layout from './components/selectFrameLayout.jsx'
 
 ipcRenderer.on('init', (event, data) => {
   ReactDOM.render(

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,5 +78,20 @@ export default [
       { file: 'dist/js/renderer/app.js', format: 'cjs', sourcemap: true, },
     ],
     ...options
+  },
+  // @todo Remove the need to bundle each new window created by electron
+  {
+    input: './app/js/renderer/selectFrame.js',
+    output: [
+      { file: 'dist/js/renderer/selectFrame.js', format: 'cjs', sourcemap: true, },
+    ],
+    ...options
+  },
+  {
+    input: './app/js/renderer/selectCondition.js',
+    output: [
+      { file: 'dist/js/renderer/selectCondition.js', format: 'cjs', sourcemap: true, },
+    ],
+    ...options
   }
 ]


### PR DESCRIPTION
- [x] Fix showOpenDialog to use the sync version. This went unnoticed in #4 due to debug task in vscode using an older version of electron.

- [x] Fix sub-windows not displaying their contents due to their JavaScript not being bundled and included.