### PR TITLE
Fix empty launch due to missing default values

### DIFF
--- a/app/js/main/appDataDefault.js
+++ b/app/js/main/appDataDefault.js
@@ -1,4 +1,6 @@
 export default {
   "main-width": 1600,
-  "main-height": 900
+  "main-height": 900,
+  "recentProjectsList": [],
+  "projectPath": ""
 }

--- a/app/js/renderer/store/index.js
+++ b/app/js/renderer/store/index.js
@@ -6,8 +6,8 @@ import { ipcRenderer } from 'electron'
 class Store extends Actions {
   @observable theme = '';
   @observable isLoaded = false;
-  @observable projectPath = ipcRenderer.sendSync('getProp', 'projectPath');
-  @observable recentProjectPaths = ipcRenderer.sendSync('getProp', 'recentProjectPaths');
+  @observable projectPath = ipcRenderer.sendSync('getProp', 'projectPath') || "";
+  @observable recentProjectPaths = ipcRenderer.sendSync('getProp', 'recentProjectPaths') || [];
   @observable mapList = [];
   @observable qMap = [];
   @observable currentMap = -1;


### PR DESCRIPTION
After some testing, I believe the empty launch window was due to missing a default value for `recentProjectPaths`. This adds default values for both `recentProjectPaths` and `projectPath`.