### PR TITLE
Fix objects disappearing when switching maps

### DIFF
--- a/app/js/renderer/display/sprite.js
+++ b/app/js/renderer/display/sprite.js
@@ -380,12 +380,12 @@ export default class Sprite extends PIXI.Sprite {
       filePath = path.join(Store.projectPath, filePath);
       const fileName = encodeURIComponent(path.basename(filePath));
       filePath = path.join(path.dirname(filePath), fileName);
-      const texture = PIXI.BaseTexture.from(filePath);
+      const texture = PIXI.BaseTexture.from(filePath)
       texture.on('error', () => {
         this.texture = PIXI.Texture.EMPTY;
         Store.notify('ERROR', 'Failed to load image.');
       })
-      if (texture.hasLoaded) {
+      if (texture.valid) {
         this.setSprite(texture);
         this.drawData();
         this.applyMeta();

--- a/app/js/renderer/display/sprite.js
+++ b/app/js/renderer/display/sprite.js
@@ -154,7 +154,6 @@ export default class Sprite extends PIXI.Sprite {
       const y = this._tempY + dy / scaleY;
       this.x = this.adjustXWithSnap(x, dx, scaleX);
       this.y = this.adjustYWithSnap(y, dy, scaleY);
-      console.log("drag:", this.y);
       this._tempX = x;
       this._tempY = y;
       this._prevPos = { ...newPos };

--- a/app/js/renderer/store/actionInput.js
+++ b/app/js/renderer/store/actionInput.js
@@ -22,7 +22,6 @@ export default (C) => {
 
     isLongPressed(keyCode) {
       if (!this.isPressed(keyCode)) return false;
-      console.log(this._lastDown);
       const dt = Date.now() - this._keyState[keyCode];
       return this.isTriggered(keyCode) || dt > 300;
     }


### PR DESCRIPTION
Fixes object disappearing when switching maps due to a deprecated Pixi method `.hasLoaded`, this PR will now add the correct property `.valid`